### PR TITLE
Make Media generic and add a message 'getContent'

### DIFF
--- a/src/main/java/de/aliceice/humanoid/media/JsonMedia.java
+++ b/src/main/java/de/aliceice/humanoid/media/JsonMedia.java
@@ -7,7 +7,7 @@ import javax.json.JsonArrayBuilder;
 import javax.json.JsonObjectBuilder;
 import javax.json.JsonValue;
 
-public final class JsonMedia implements Media {
+public final class JsonMedia implements Media<JsonValue> {
     
     @Override
     public void print(String name, String value) {
@@ -31,9 +31,9 @@ public final class JsonMedia implements Media {
     
     @Override
     public void print(String name, Response response) {
-        JsonMedia value = new JsonMedia();
-        response.printOn(value);
-        this.json.add(name, value.getJson());
+        JsonMedia media = new JsonMedia();
+        response.printOn(media);
+        this.json.add(name, media.getContent());
     }
     
     @Override
@@ -42,12 +42,13 @@ public final class JsonMedia implements Media {
         collection.forEach(response -> {
             JsonMedia entry = new JsonMedia();
             response.printOn(entry);
-            arrayBuilder.add(entry.getJson());
+            arrayBuilder.add(entry.getContent());
         });
         this.json.add(name, arrayBuilder.build());
     }
     
-    public JsonValue getJson() {
+    @Override
+    public JsonValue getContent() {
         return this.json.build();
     }
     

--- a/src/main/java/de/aliceice/humanoid/media/Media.java
+++ b/src/main/java/de/aliceice/humanoid/media/Media.java
@@ -3,7 +3,7 @@ package de.aliceice.humanoid.media;
 import de.aliceice.humanoid.Response;
 import java.util.Collection;
 
-public interface Media {
+public interface Media<T> {
     
     void print(String name, String value);
     
@@ -16,4 +16,7 @@ public interface Media {
     void print(String name, Response collection);
     
     void print(String name, Collection<Response> collection);
+    
+    T getContent();
+    
 }

--- a/src/test/java/de/aliceice/humanoid/media/JsonMediaTest.java
+++ b/src/test/java/de/aliceice/humanoid/media/JsonMediaTest.java
@@ -11,31 +11,31 @@ public final class JsonMediaTest {
     @Test
     public void printString() throws Exception {
         this.subject.print("Field", "Value");
-        assertEquals("{\"Field\":\"Value\"}", this.subject.getJson().toString());
+        assertEquals("{\"Field\":\"Value\"}", this.subject.getContent().toString());
     }
     
     @Test
     public void printInteger() throws Exception {
         this.subject.print("Field", 1);
-        assertEquals("{\"Field\":1}", this.subject.getJson().toString());
+        assertEquals("{\"Field\":1}", this.subject.getContent().toString());
     }
     
     @Test
     public void printFloat() throws Exception {
         this.subject.print("Field", 1.f);
-        assertEquals("{\"Field\":1.0}", this.subject.getJson().toString());
+        assertEquals("{\"Field\":1.0}", this.subject.getContent().toString());
     }
     
     @Test
     public void printDouble() throws Exception {
         this.subject.print("Field", 1.d);
-        assertEquals("{\"Field\":1.0}", this.subject.getJson().toString());
+        assertEquals("{\"Field\":1.0}", this.subject.getContent().toString());
     }
     
     @Test
     public void printResponse() throws Exception {
         this.subject.print("Field", new StringResponse("Embedded Field", "Value"));
-        assertEquals("{\"Field\":{\"Embedded Field\":\"Value\"}}", this.subject.getJson().toString());
+        assertEquals("{\"Field\":{\"Embedded Field\":\"Value\"}}", this.subject.getContent().toString());
     }
     
     @Test
@@ -43,7 +43,7 @@ public final class JsonMediaTest {
         this.subject.print("Field", Arrays.asList(new StringResponse("Embedded Field", "Value"),
                                                   new StringResponse("Embedded Field", "Value")));
         assertEquals("{\"Field\":[{\"Embedded Field\":\"Value\"},{\"Embedded Field\":\"Value\"}]}",
-                     this.subject.getJson().toString());
+                     this.subject.getContent().toString());
     }
     
     private final JsonMedia subject = new JsonMedia();


### PR DESCRIPTION
The Media interface lacked a way to generally get the printed
content. To fix this Media is now generic and defines the
message 'getContent' to retrieve the current content.

This fixes #15