### PR TITLE
Add japicmp-maven-plugin to code-quality profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # humanoid
+
+# Create a compatibility report
+Execute the following:
+
+`mvn clean verify -Pcompatibility-report -DoldVersion=$(curl https://oss.sonatype.org/content/repositories/public/de/aliceice/humanoid/maven-metadata.xml | grep release | sed -E 's/.*<release>(.*)<.*/\1/')`
+
+The report is located under `target/japicmp/japicmp.html`

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${versions.build.jacoco-maven-plugin}</version>
                 </plugin>
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <version>0.10.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -378,6 +383,34 @@
                                     <goal>prepare-agent</goal>
                                     <goal>report</goal>
                                     <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>compatibility-report</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.siom79.japicmp</groupId>
+                        <artifactId>japicmp-maven-plugin</artifactId>
+                        <configuration>
+                            <oldVersion>
+                                <dependency>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>${project.artifactId}</artifactId>
+                                    <version>${oldVersion}</version>
+                                </dependency>
+                            </oldVersion>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>cmp</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
This will help in the future to analyse changes between versions,
especially by suggesting a semantic version increase.

This fixes #41